### PR TITLE
verification updates

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,2 @@
-irc
-irc2
+irc?
+irc2?

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,4 @@
 irc?
 irc2?
+killme?
+mesecons_commandblock?

--- a/init.lua
+++ b/init.lua
@@ -11,8 +11,8 @@ verification.announced = {}
 local function announce_player(player, name)
    local umsg = "Player " .. name .. " is unverified."
    minetest.chat_send_all(umsg)
-   irc:say(umsg)
-   irc2:say(umsg)
+   if minetest.get_modpath("irc") then irc:say(umsg) end
+   if minetest.get_modpath("irc2") then irc2:say(umsg) end
    minetest.chat_send_player(name, verification.message)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,25 @@
+local mod_storage = minetest.get_mod_storage()
+
+local function mod_storage_get_bool(name, default)
+   local value = mod_storage:get_string(name)
+   if value == ''
+      then return default
+   else
+      return value == 'true'
+   end
+end
+
+local function mod_storage_set_bool(name, value)
+   if value == true then
+      value = 'true'
+   else
+      value = 'false'
+   end
+   return mod_storage:set_string(name, value)
+end
+
 verification = {}
-verification.on = true
+verification.on = mod_storage_get_bool('on', true)
 verification.default_privs = {interact = true, shout = true, home = true }
 verification.unverified_privs = {unverified = true, shout = true}
 verification.release_location = {x = 111, y = 13, z = -507}
@@ -126,6 +146,7 @@ minetest.register_chatcommand("toggle_verification", {
    privs = {server = true},
    func = function(_, _)
       verification.on = not verification.on
+      mod_storage_set_bool('on', verification.on)
       local status = verification.on and "on" or "off"
       return true, "Player verification is now " .. status
    end

--- a/init.lua
+++ b/init.lua
@@ -82,35 +82,31 @@ minetest.register_on_chat_message(function(name, message)
    return false
 end)
 
--- Disable the use of /me for unverified users
-local oldme = minetest.registered_chatcommands["me"]
-local oldmefunc = minetest.registered_chatcommands["me"].func
-minetest.override_chatcommand("me", {
-   params = oldme.params,
-   privs = oldme.privs,
-   func = function(name, param)
-      if minetest.check_player_privs(name, {unverified = true}) then
-         return false, "Only verified users can use /me"
-      else
-         return oldmefunc(name, param)
-      end
-   end
-})
 
--- Disable PMs from unverified users
-local olddef = minetest.registered_chatcommands["msg"]
-local oldfunc = minetest.registered_chatcommands["msg"].func
-minetest.override_chatcommand("msg", {
-   params = olddef.params,
-   privs = olddef.privs,
-   func = function(name, param)
-      if minetest.check_player_privs(name, {unverified = true}) then
-         return false, "Only verified users can send private messages"
-      else
-         return oldfunc(name, param)
-      end
+local function override_cmd(cmd)
+   local olddef = minetest.registered_chatcommands[cmd]
+   if olddef then
+      minetest.override_chatcommand(cmd, {
+         description = olddef.description,
+         params = olddef.params,
+         privs = olddef.privs,
+         func = function(name, param)
+            if minetest.check_player_privs(name, {unverified = true}) then
+               return false, "Only verified users can use /" .. cmd
+            else
+               return olddef.func(name, param)
+            end
+         end
+      })
    end
-})
+end
+
+-- disable these commands
+override_cmd("me")
+override_cmd("msg")
+override_cmd("killme")
+override_cmd("irc_msg")
+override_cmd("irc2_msg")
 
 -- Verify command
 minetest.register_chatcommand("verify", {

--- a/init.lua
+++ b/init.lua
@@ -104,6 +104,7 @@ end
 -- disable these commands
 override_cmd("me")
 override_cmd("msg")
+override_cmd("tell")
 override_cmd("killme")
 override_cmd("irc_msg")
 override_cmd("irc2_msg")

--- a/init.lua
+++ b/init.lua
@@ -57,6 +57,12 @@ minetest.register_on_joinplayer(function(player)
          -- Announce the player
          announce_player(player, n)
       end)
+   else
+      local n = player:get_player_name()
+      if minetest.check_player_privs(n, {unverified = true}) then
+         -- if an unverified player joins while verification is off, verify them.
+         verification.verify(n)
+      end
    end
 end)
 


### PR DESCRIPTION
I've "fixed" some behaviour of the verification mod I find slightly annoying.

1. Verify unverified players if verification is off.
2. Disable /killme and /irc_msg for unverified players. /killme allows players to escape the holding area.
3. Persist verification state across server reboot (using mod_storage).

Tested on a local server w/ a BlS-like modpack